### PR TITLE
feat: add model combo in the main windows and a button to get its info

### DIFF
--- a/.kdev4/alpaka.kdev4
+++ b/.kdev4/alpaka.kdev4
@@ -1,0 +1,41 @@
+[Buildset]
+BuildItems=@Variant(\x00\x00\x00\t\x00\x00\x00\x00\x01\x00\x00\x00\x0b\x00\x00\x00\x00\x01\x00\x00\x00\x0c\x00a\x00l\x00p\x00a\x00k\x00a)
+
+[CMake]
+Build Directory Count=1
+Current Build Directory Index-Host System=0
+
+[CMake][CMake Build Directory 0]
+Build Directory Path=/home/siavoshk/Src/alpaka/build
+Build Type=Debug
+CMake Binary=/usr/bin/cmake
+CMake Executable=/usr/bin/cmake
+Environment Profile=
+Extra Arguments=
+Install Directory=
+Runtime=Host System
+
+[Launch]
+Launch Configurations=Launch Configuration 0
+
+[Launch][Launch Configuration 0]
+Configured Launch Modes=execute
+Configured Launchers=nativeAppLauncher
+Name=New Compiled Binary Launcher
+Type=Native Application
+
+[Launch][Launch Configuration 0][Data]
+Arguments=
+Dependencies=@Variant(\x00\x00\x00\t\x00\x00\x00\x00\x00)
+Dependency Action=Nothing
+EnvironmentGroup=
+Executable=file:///home/siavoshk/Src/alpaka
+External Terminal=konsole --noclose --workdir %workdir -e %exe
+Kill Before Executing Again=4194304
+Project Target=alpaka,src,apps,alpaka
+Use External Terminal=false
+Working Directory=
+isExecutable=false
+
+[Project]
+VersionControlSupport=kdevgit

--- a/alpaka.kdev4
+++ b/alpaka.kdev4
@@ -1,0 +1,4 @@
+[Project]
+CreatedFrom=CMakeLists.txt
+Manager=KDevCMakeManager
+Name=alpaka

--- a/src/apps/ChatModel.cpp
+++ b/src/apps/ChatModel.cpp
@@ -140,6 +140,35 @@ void ChatModel::sendMessage(const QString &message)
     endInsertRows();
 }
 
+void ChatModel::getModelInfo()
+{
+    KLLMRequest req{QString{}};
+    req.setModel(KLLMCoreSettings::model());
+
+    auto rep = m_llm->getModelInfo(req);
+    beginInsertRows({}, m_messages.size(), m_messages.size() + 1);
+    m_messages.append(ChatMessage{.content = QString::fromLatin1("Show model info."), .sender = Sender::User});
+    m_messages.append(ChatMessage{.inProgress = true, .sender = Sender::LLM, .llmReply = rep});
+    m_connections.insert(rep, connect(rep, &KLLMReply::contentAdded, this, [this, i = m_messages.size() - 1] {
+                             auto &message = m_messages[i];
+                             message.content = message.llmReply->readResponse();
+                             Q_EMIT dataChanged(index(i), index(i), {Roles::MessageRole});
+                         }));
+    m_connections.insert(rep, connect(rep, &KLLMReply::finished, this, [this, i = m_messages.size() - 1] {
+                             auto &message = m_messages[i];
+                             m_connections.remove(message.llmReply);
+                             message.llmReply->deleteLater();
+                             message.llmReply = nullptr;
+                             message.inProgress = false;
+                             Q_EMIT dataChanged(index(i),
+                                                index(i),
+                                                {Roles::FinishedRole, Roles::TokensPerSecondRole, Roles::TokenCountRole, Roles::DurationRole});
+                             Q_EMIT replyInProgressChanged();
+                         }));
+    Q_EMIT replyInProgressChanged();
+    endInsertRows();
+}
+
 void ChatModel::resetConversation()
 {
     beginResetModel();

--- a/src/apps/ChatModel.h
+++ b/src/apps/ChatModel.h
@@ -50,6 +50,7 @@ public:
 
 public Q_SLOTS:
     void sendMessage(const QString &message);
+    void getModelInfo();
     void resetConversation();
 
 Q_SIGNALS:

--- a/src/apps/qml/ChatView.qml
+++ b/src/apps/qml/ChatView.qml
@@ -13,6 +13,10 @@ import org.kde.alpaka
 Kirigami.ScrollablePage {
     title: i18n("Alpaka")
 
+    Component.onCompleted: {
+        modelCombo.currentIndex = modelCombo.indexOfValue(AlpakaSettings.model);
+    }
+
     Kirigami.Theme.colorSet: Kirigami.Theme.Window
     Connections {
         target: chat.llm
@@ -22,8 +26,10 @@ Kirigami.ScrollablePage {
         }
     }
 
+
     leftPadding: 30
     actions: [
+
         Kirigami.Action {
             text: i18nc("@action:intoolbar", "Start Over")
             icon.name: "view-refresh"
@@ -58,6 +64,7 @@ Kirigami.ScrollablePage {
         Kirigami.Separator {
             Layout.fillWidth: true
         }
+
         Controls.TextField {
             id: messageInput
 
@@ -73,6 +80,26 @@ Kirigami.ScrollablePage {
                 messageInput.text = "";
             }
         }
+        Kirigami.Separator {
+            Layout.fillWidth: true
+        }
+        RowLayout {
+            Layout.margins: Kirigami.Units.smallSpacing
+            Controls.Label {
+                text: i18n("LLM model:")
+
+            }
+            Controls.ComboBox {
+                id: modelCombo
+                model: chat.llm.models
+                onCurrentTextChanged: AlpakaSettings.model = currentText
+            }
+            Controls.Button {
+                text: "Info"
+                onClicked: chat.getModelInfo()
+            }
+        }
+
     }
 
     Kirigami.PlaceholderMessage {

--- a/src/apps/qml/LLMSettingsPage.qml
+++ b/src/apps/qml/LLMSettingsPage.qml
@@ -14,19 +14,11 @@ FormCard.FormCardPage {
 
     Component.onCompleted: {
         prompt.text = AlpakaSettings.systemPrompt;
-        modelCombo.currentIndex = modelCombo.indexOfValue(AlpakaSettings.model);
         llmDebugInfo.checked = AlpakaSettings.showDebugInfo;
     }
 
     FormCard.FormCard {
         Layout.topMargin: Kirigami.Units.largeSpacing
-        FormCard.FormComboBoxDelegate {
-            id: modelCombo
-
-            text: i18n("LLM model")
-            model: chat.llm.models
-            onCurrentTextChanged: AlpakaSettings.model = currentText
-        }
 
         FormCard.AbstractFormDelegate {
             id: prompt

--- a/src/core/KLLMInterface.h
+++ b/src/core/KLLMInterface.h
@@ -143,6 +143,18 @@ public Q_SLOTS:
     KLLMReply *getCompletion(const KLLMRequest &request);
 
     /**
+     * @brief Request model info from the Ollama.
+     *
+     * Calling this function starts a request to the LLM backend. You should use the returned KLLMReply pointer to track the
+     * status of the LLM's response. Once the KLLMReply emits KLLMReply::finished(), it is your responsibility to either
+     * track or delete the KLLMReply; auto-deleting is not implemented yet.
+     *
+     * @param request The request object that will be used to create the actual LLM request.
+     * @return Returns a pointer to a KLLMReply that can be used to track the progress of the reply.
+     */
+    KLLMReply *getModelInfo(const KLLMRequest &request);
+
+    /**
      * @brief Reload the LLM interface.
      *
      * Reloading the interface can be used to check if a network error is gone or to see if the available models have changed.

--- a/src/core/KLLMReply.cpp
+++ b/src/core/KLLMReply.cpp
@@ -11,14 +11,15 @@
 using namespace Qt::StringLiterals;
 using namespace KLLMCore;
 
-KLLMReply::KLLMReply(QNetworkReply *netReply, QObject *parent)
+KLLMReply::KLLMReply(QNetworkReply *netReply, QObject *parent, RequestTypes requestType)
     : QObject{parent}
     , m_reply{netReply}
+    , m_requestType{requestType}
 {
     connect(m_reply, &QNetworkReply::finished, m_reply, [this] {
         // Normally, we could assume that the tokens will never be empty once the request finishes, but it could be possible
         // that the request failed and we have no tokens to parse.
-        if (!m_tokens.empty()) {
+        if (m_requestType == RequestTypes::StreamingGenerate && !m_tokens.empty()) {
             const auto finalResponse = m_tokens.constLast();
             m_context.setOllamaContext(finalResponse["context"_L1].toArray());
             m_info.totalDuration = std::chrono::nanoseconds{finalResponse["total_duration"_L1].toVariant().toULongLong()};
@@ -39,19 +40,24 @@ KLLMReply::KLLMReply(QNetworkReply *netReply, QObject *parent)
     connect(m_reply, &QNetworkReply::downloadProgress, m_reply, [this](qint64 received, qint64 /*total*/) {
         m_incompleteTokens += m_reply->read(received - m_receivedSize);
         m_receivedSize = received;
+        switch (m_requestType) {
+        case RequestTypes::Show:
+            m_tokens.append(QJsonDocument::fromJson(m_incompleteTokens));
+            break;
+        case RequestTypes::StreamingGenerate:
+            auto completeTokens = m_incompleteTokens.split('\n');
+            if (completeTokens.size() <= 1) {
+                return;
+            }
+            m_incompleteTokens = completeTokens.last();
+            completeTokens.removeLast();
 
-        auto completeTokens = m_incompleteTokens.split('\n');
-        if (completeTokens.size() <= 1) {
-            return;
+            m_tokens.reserve(completeTokens.count());
+            for (const auto &tok : std::as_const(completeTokens)) {
+                m_tokens.append(QJsonDocument::fromJson(tok));
+            }
+            break;
         }
-        m_incompleteTokens = completeTokens.last();
-        completeTokens.removeLast();
-
-        m_tokens.reserve(completeTokens.count());
-        for (const auto &tok : completeTokens) {
-            m_tokens.append(QJsonDocument::fromJson(tok));
-        }
-
         Q_EMIT contentAdded();
     });
 }
@@ -59,8 +65,22 @@ KLLMReply::KLLMReply(QNetworkReply *netReply, QObject *parent)
 QString KLLMReply::readResponse() const
 {
     QString ret;
-    for (const auto &tok : m_tokens)
-        ret += tok["response"_L1].toString();
+    switch (m_requestType) {
+    case RequestTypes::Show:
+        ret += QString::fromLatin1("## Template: \n```\n") + m_tokens.constFirst()["template"_L1].toString() + QString::fromLatin1("\n```\n");
+        ret += QString::fromLatin1("## Modelfile: \n```\n") + m_tokens.constFirst()["modelfile"_L1].toString() + QString::fromLatin1("\n```\n");
+        ret += QString::fromLatin1("## Parameters: \n```\n") + m_tokens.constFirst()["parameters"_L1].toString() + QString::fromLatin1("\n```\n");
+        ret += QString::fromLatin1("## Details: \n```\n")
+            + QString::fromLatin1(QJsonDocument::fromVariant(m_tokens.constFirst()["details"_L1].toVariant()).toJson()) + QString::fromLatin1("\n```\n");
+        ret += QString::fromLatin1("## Model Info: \n```\n")
+            + QString::fromLatin1(QJsonDocument::fromVariant(m_tokens.constFirst()["model_info"_L1].toVariant()).toJson()) + QString::fromLatin1("\n```\n");
+        break;
+    case RequestTypes::StreamingGenerate:
+        for (const auto &tok : m_tokens)
+            ret += tok["response"_L1].toString();
+        break;
+    }
+
     return ret;
 }
 
@@ -72,6 +92,11 @@ const KLLMContext &KLLMReply::context() const
 const KLLMReplyInfo &KLLMReply::info() const
 {
     return m_info;
+}
+
+const KLLMReply::RequestTypes &KLLMReply::requestType() const
+{
+    return m_requestType;
 }
 
 bool KLLMReply::isFinished() const

--- a/src/core/KLLMReply.h
+++ b/src/core/KLLMReply.h
@@ -56,6 +56,15 @@ class KLLMCORE_EXPORT KLLMReply : public QObject
 
 public:
     /**
+     * @brief Specifies the request type.
+     *
+     * When the class in instantiated the type of request should be specified
+     */
+    enum class RequestTypes {
+        StreamingGenerate,
+        Show
+    };
+    /**
      * @brief Get the current response content.
      *
      * This function returns what it has recieved of the response so far. Therefore, until finished() is emitted, this
@@ -67,7 +76,7 @@ public:
     [[nodiscard]] QString readResponse() const;
 
     /**
-     * @brief Get the context token for this response.
+     * @brief Get the context token for this response (if applicable).
      *
      * Messages sent by most LLMs have a context identifier that allows you to chain messages into a conversation. To create
      * such a conversation, you need to take this context object and set it on the next KLLMRequest in the conversation.
@@ -78,7 +87,7 @@ public:
     const KLLMContext &context() const;
 
     /**
-     * @brief Get extra information about the reply.
+     * @brief Get extra information about the reply (if applicable).
      *
      * This function returns a KLLMReplyInfo object containing information about this reply. If the reply has not finished, the KLLMReplyInfo object will have
      * all members set to their default values.
@@ -96,8 +105,17 @@ public:
      */
     [[nodiscard]] bool isFinished() const;
 
+    /**
+     * @brief Get request type.
+     *
+     * The request type is set when this object is created.
+     *
+     * @return Corresponding request type.
+     */
+    const RequestTypes &requestType() const;
+
 protected:
-    explicit KLLMReply(QNetworkReply *netReply, QObject *parent = nullptr);
+    explicit KLLMReply(QNetworkReply *netReply, QObject *parent = nullptr, RequestTypes requestType = RequestTypes::StreamingGenerate);
 
     friend class KLLMInterface;
 
@@ -128,6 +146,7 @@ private:
 
     KLLMContext m_context;
     KLLMReplyInfo m_info;
+    RequestTypes m_requestType = RequestTypes::StreamingGenerate;
 
     int m_receivedSize = 0;
     bool m_finished = false;


### PR DESCRIPTION
1. Created a new combo box in the footer of the main chat window to select the desired model in place.
2. Added a button to get model info.
3. Extended KLLMReply class to handle new non streaming response types.
4. Removed model selector from settings.

![image](https://github.com/user-attachments/assets/29d77b13-722a-491d-9aed-dcc4effdf752)
